### PR TITLE
refactor ackermann caching

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 ackermann
 ---------
 - [ ] make the caching more generic by moving from a 2D dict `cache[m][n]=a` to an args tuple `cache[(m,n)]=a`
+    - [X] refactor the cache dict into this format
+    - [ ] refator the caching methods to use this format
 - [ ] consider if caching can be done as a decorator rather than integrating it into the function
 - [ ] consider if we should move `cache.__str__` to `cache.__repr__` since it's not intended for public consumption
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,11 @@
 ackermann
 ---------
-- [ ] make the caching more generic by moving from a 2D dict `cache[m][n]=a` to an args tuple `cache[(m,n)]=a`
+- [X] make the caching more generic by moving from a 2D dict `cache[m][n]=a` to an args tuple `cache[(m,n)]=a`
     - [X] refactor the cache dict into this format
-    - [ ] refator the caching methods to use this format
+    - [X] refator the caching methods to use this format
 - [ ] consider if caching can be done as a decorator rather than integrating it into the function
 - [ ] consider if we should move `cache.__str__` to `cache.__repr__` since it's not intended for public consumption
+- [ ] consider moving to csv writer for persisting the cache data
 
 life
 ----

--- a/src/ackermann/ackermann.py
+++ b/src/ackermann/ackermann.py
@@ -17,15 +17,15 @@ class AckermannCache:
         self.size = 0
         self.read_size = 0
 
-    def add_cache(self, m, n, value):
+    def add_cache(self, args: tuple, value: int):
         """Add a result to the internal cache."""
-        self.cache[(m,n)] = value
+        self.cache[args] = value
         self.size += 1
 
-    def get_cache(self, m: int, n: int) -> int:
+    def get_cache(self, args: tuple) -> int:
         """Get a result from the internal cache."""
         try:
-            result = self.cache[(m, n)]
+            result = self.cache[args]
         except KeyError:
             result = False
         return result
@@ -35,7 +35,7 @@ class AckermannCache:
         with open(filename) as file:
             for line in file:
                 m, n, value = line.strip().split(',')
-                self.add_cache(int(m), int(n), int(value))
+                self.add_cache((int(m), int(n)), int(value))
         self.read_size = self.size
 
     def save_cache(self, filename: str):
@@ -51,7 +51,7 @@ class AckermannCache:
         This is recursive and grows quite quickly.
         Caching is used to avoid re-computing known values.
         """
-        result = self.get_cache(m, n)
+        result = self.get_cache((m, n))
         if result:
             return result
         result = 0
@@ -62,7 +62,7 @@ class AckermannCache:
                 result = self.get_ackermann(m-1, 1)
             else:
                 result = self.get_ackermann(m-1, self.get_ackermann(m, n-1))
-            self.add_cache(m, n, result)
+            self.add_cache((m, n), result)
         except RuntimeError as error:
             raise AckermannOverflowError(
                 f'Recursion limit of {sys.getrecursionlimit()}'

--- a/src/ackermann/ackermann.py
+++ b/src/ackermann/ackermann.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python2
 # -*- coding: utf-8 -*-
 import sys
-from typing import Dict
 
 class AckermannOverflowError(RuntimeError):
     """Error class for ackermann"""
@@ -14,23 +13,19 @@ class AckermannCache:
 
     def __init__(self):
         sys.setrecursionlimit(25000)
-        self.cache: Dict[int, Dict[int, int]] = {}
+        self.cache: dict[tuple, int] = {}
         self.size = 0
         self.read_size = 0
 
     def add_cache(self, m, n, value):
         """Add a result to the internal cache."""
-        try:
-            self.cache[m]
-        except KeyError:
-            self.cache[m] = {}
-        self.cache[m][n] = value
+        self.cache[(m,n)] = value
         self.size += 1
 
     def get_cache(self, m: int, n: int) -> int:
         """Get a result from the internal cache."""
         try:
-            result = self.cache[m][n]
+            result = self.cache[(m, n)]
         except KeyError:
             result = False
         return result
@@ -48,9 +43,8 @@ class AckermannCache:
         if self.size <= self.read_size:
             return
         with open(filename, 'w') as file:
-            for m in self.cache:
-                for n in self.cache[m]:
-                    print(f'{m},{n},{self.cache[m][n]}', file=file)
+            for (m, n), value in self.cache.items():
+                print(f'{m},{n},{value}', file=file)
 
     def get_ackermann(self, m: int, n: int) -> int:
         """Calculate the ackermann-péter function of m and n.
@@ -79,11 +73,8 @@ class AckermannCache:
     def __str__(self):
         """Show the contents of the cache for debugging purposes."""
         result = []
-        for m in self.cache:
-            row = []
-            for n in self.cache[m]:
-                row.append(f'({m}, {n}) = {self.cache[m][n]}')
-            result.append('; '.join(row))
+        for (m, n), value in self.cache.items():
+            result.append(f'({m}, {n}) = {value}')
         return '\n'.join(result)
 
     def ackermann_grid(self):


### PR DESCRIPTION
refactor our caching experiment to be more general by using args tuple instead of individual values as the key to the cache store