### PR TITLE
life - improved rendering

### DIFF
--- a/src/life/__main__.py
+++ b/src/life/__main__.py
@@ -6,23 +6,29 @@ from life.generation import Generation
 from life.game import Game
 from life.rule import DEFAULT_RULE, Rule
 
+
+DEFAULT_DELAY = 0.01
+
+
 def parse_args():
     parser = ArgumentParser()
     parser.add_argument('width', nargs='?', default=40, type=int)
     parser.add_argument('height', nargs='?', default=20, type=int)
     parser.add_argument('-r', '--rules', default=DEFAULT_RULE, type=Rule)
+    parser.add_argument('-d', '--delay', default=DEFAULT_DELAY, type=float)
     return parser.parse_args()
 
-def core_loop(game: Game):
+def core_loop(game: Game, delay: int = DEFAULT_DELAY):
     """Perform the game by iterating steps until activity ceases.
     At each generation we clear the screen and display the current generation.
-    We sleep for 0.1 seconds between each generations.
     """
     try:
         for generation in game:
+            # Since it takes a moment to render, we do that before clearing to avoid flickering
+            display = str(generation)
             system('clear')
-            print(generation)
-            sleep(0.1)
+            print(display)
+            sleep(delay)
     except KeyboardInterrupt:
         pass
     print(f'game ended at generation {game.generations}')
@@ -33,7 +39,7 @@ def main():
     """
     config = parse_args()
     game = Game(Generation.random(config.height, config.width), config.rules)
-    core_loop(game)
+    core_loop(game, delay=config.delay)
 
 
 if __name__ == '__main__':

--- a/src/life/__main__.py
+++ b/src/life/__main__.py
@@ -18,7 +18,7 @@ def parse_args():
     parser.add_argument('-d', '--delay', default=DEFAULT_DELAY, type=float)
     return parser.parse_args()
 
-def core_loop(game: Game, delay: int = DEFAULT_DELAY):
+def core_loop(game: Game, delay: float = DEFAULT_DELAY):
     """Perform the game by iterating steps until activity ceases.
     At each generation we clear the screen and display the current generation.
     """

--- a/src/life/game.py
+++ b/src/life/game.py
@@ -14,7 +14,8 @@ class Game:
         self.current_gen = gen
         self.height = len(gen._grid)
         self.width = len(gen._grid[0])
-        self.end_threshold = log(self.height*self.width)
+        area = self.height*self.width
+        self.end_threshold = area/(50*log(area))
         self.history: list[Generation] = []
         self.generations = 0
         self.rule = rule
@@ -32,7 +33,12 @@ class Game:
             return True
         generational_average = 0
         for generation in self.history:
-            generational_average += self.current_gen ^ generation
+            if differences := self.current_gen ^ generation:
+                generational_average += differences
+            else:
+                # If generations are identical the only life left is
+                # still life or ocillators with period <= GENERATIONSTOKEEP
+                return False
         generational_average /= len(self.history)
         return generational_average > self.end_threshold
 

--- a/src/life/game.py
+++ b/src/life/game.py
@@ -15,7 +15,7 @@ class Game:
         self.height = len(gen._grid)
         self.width = len(gen._grid[0])
         area = self.height*self.width
-        self.end_threshold = area/(50*log(area))
+        self.end_threshold = area / (50 * (log(area)+1))
         self.history: list[Generation] = []
         self.generations = 0
         self.rule = rule

--- a/tests/life/test_game.py
+++ b/tests/life/test_game.py
@@ -26,7 +26,7 @@ class TestGame:
         grid = Game(self.tiny_true, rule)
         grid.history = history[:]
         actual = grid.has_activity()
-        assert actual == expected
+        assert actual is expected
 
     @pytest.mark.parametrize('prehistory, generation, expected', (
         (


### PR DESCRIPTION
Reduced flicker in by moving the display order to render -> clear -> display rather than clear -> render -> display.
Minor improvement for end-detection algorithm
* the previous change overcorrected to to small a margin, moved to a/log(a) (logarithmic proportion of the area)
* for further development of this we can look into tweaking the denominator based on the survival rules